### PR TITLE
Change Home and ExerciseSet data fetching to not throw

### DIFF
--- a/Lumbly/Sources/Features/ExerciseSet/ExerciseSetView.swift
+++ b/Lumbly/Sources/Features/ExerciseSet/ExerciseSetView.swift
@@ -116,7 +116,7 @@ struct ExerciseSetView: View {
             }
         }
         .task {
-            try? await viewModel.fetchExerciseSetData()
+            await viewModel.fetchExerciseSetData()
         }
     }
 }

--- a/Lumbly/Sources/Features/ExerciseSet/ExerciseSetViewModel.swift
+++ b/Lumbly/Sources/Features/ExerciseSet/ExerciseSetViewModel.swift
@@ -26,7 +26,7 @@ extension ExerciseSetView {
             self.exerciseSetURL = exerciseSetURL
         }
         
-        @MainActor func fetchExerciseSetData() async throws {
+        @MainActor func fetchExerciseSetData() async {
             guard !isLoading else { return }
             defer { isLoading = false }
             isLoading = true
@@ -36,7 +36,7 @@ extension ExerciseSetView {
             
             let request = APIRequest(resource: resource)
 
-            exerciseSetData = try await request.execute()
+            exerciseSetData = try? await request.execute()
         }
     }
 }

--- a/Lumbly/Sources/Features/Home/HomeView.swift
+++ b/Lumbly/Sources/Features/Home/HomeView.swift
@@ -137,7 +137,7 @@ struct HomeView: View {
             self.navigationBarHidden = true
         }
         .task {
-            try? await viewModel.fetchHomeData()
+            await viewModel.fetchHomeData()
         }
     }
 }

--- a/Lumbly/Sources/Features/Home/HomeViewModel.swift
+++ b/Lumbly/Sources/Features/Home/HomeViewModel.swift
@@ -42,11 +42,11 @@ extension HomeView {
             return result
         }
         
-        @MainActor func fetchHomeData() async throws {
+        @MainActor func fetchHomeData() async {
             let resource = HomeResource()
             let request = APIRequest(resource: resource)
 
-            homeData = try await request.execute()
+            homeData = try? await request.execute()
         }
     }
 }


### PR DESCRIPTION
Changed API request execution from `try` to `try?`, and remove corresponding `throws` from function declaration and `try?` from corresponding view. This change was made for Home and ExerciseSet.