### PR TITLE
Add user ID to networking

### DIFF
--- a/Lumbly/Sources/Services/Networking/APIEndpoints/APIEndpoints.swift
+++ b/Lumbly/Sources/Services/Networking/APIEndpoints/APIEndpoints.swift
@@ -7,6 +7,7 @@
 
 enum APIEndpoints: RawRepresentable, APIProtocol {
     static let baseURL = URL(string: "https://temporarylumblyfunction.azurewebsites.net/api")
+    static let userID = "testuser1" // For demo purposes, user authentication was not implemented
     
     case connectionString
     case home


### PR DESCRIPTION
Set a constant value for a user ID, for demo purposes. In reality, this would be replaced with a user-specific ID based on their login details.