### PR TITLE
Update NetworkError to separate HTTP- and upload-related errors

### DIFF
--- a/Lumbly/Sources/Services/Networking/APIRequest.swift
+++ b/Lumbly/Sources/Services/Networking/APIRequest.swift
@@ -47,21 +47,21 @@ private extension APIRequest {
         case 200..<300:
             return
         case 400:
-            throw NetworkError.badRequest
+            throw NetworkError.HTTPError.badRequest
         case 401:
-            throw NetworkError.unauthorized
+            throw NetworkError.HTTPError.unauthorized
         case 402:
-            throw NetworkError.paymentRequired
+            throw NetworkError.HTTPError.paymentRequired
         case 403:
-            throw NetworkError.forbidden
+            throw NetworkError.HTTPError.forbidden
         case 404:
-            throw NetworkError.notFound
+            throw NetworkError.HTTPError.notFound
         case 413:
-            throw NetworkError.requestEntityTooLarge
+            throw NetworkError.HTTPError.requestEntityTooLarge
         case 422:
-            throw NetworkError.unprocessableEntity
+            throw NetworkError.HTTPError.unprocessableEntity
         default:
-            throw NetworkError.unknown(data: data, response: httpResponse)
+            throw NetworkError.HTTPError.unknown(data: data, response: httpResponse)
         }
     }
 }

--- a/Lumbly/Sources/Services/Networking/NetworkError.swift
+++ b/Lumbly/Sources/Services/Networking/NetworkError.swift
@@ -9,15 +9,16 @@ import Foundation
 
 enum NetworkError: Error {
     case malformedURL
-
-    case badRequest
-    case unauthorized
-    case paymentRequired
-    case forbidden
-    case notFound
-    case requestEntityTooLarge
-    case unprocessableEntity
-    case unknown(data: Data, response: URLResponse)
-
     case invalidResponse(data: Data)
+    
+    enum HTTPError: Error {
+        case badRequest
+        case unauthorized
+        case paymentRequired
+        case forbidden
+        case notFound
+        case requestEntityTooLarge
+        case unprocessableEntity
+        case unknown(data: Data, response: URLResponse)
+    }
 }

--- a/Lumbly/Sources/Services/Networking/NetworkError.swift
+++ b/Lumbly/Sources/Services/Networking/NetworkError.swift
@@ -21,4 +21,11 @@ enum NetworkError: Error {
         case unprocessableEntity
         case unknown(data: Data, response: URLResponse)
     }
+    
+    enum UploadError: Error {
+        case badConnectionString
+        case containerCreationFailure
+        case dataExtractionFailure
+        case uploadFailure
+    }
 }


### PR DESCRIPTION
Move HTTP errors into a separate nested enum and add new nested enum of upload errors