### PR TITLE
Change removeTemporaryVideo() to specify file URL to remove

### DIFF
--- a/Lumbly.xcodeproj/project.pbxproj
+++ b/Lumbly.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		640C29D22BD9F7870097D444 /* ResultsAvailabilityResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640C29C42BD9F7870097D444 /* ResultsAvailabilityResource.swift */; };
 		640C29D32BD9F7870097D444 /* ResultsResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640C29C52BD9F7870097D444 /* ResultsResource.swift */; };
 		640C29D42BD9F7870097D444 /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640C29C72BD9F7870097D444 /* APIRequest.swift */; };
+		640C29DC2BDA012D0097D444 /* FileManager+RemoveFileAtURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640C29DB2BDA012D0097D444 /* FileManager+RemoveFileAtURL.swift */; };
 		64924A582BC499DD001E6C43 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 649249FB2BC499DD001E6C43 /* Assets.xcassets */; };
 		64924A592BC499DD001E6C43 /* Strings+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649249FD2BC499DD001E6C43 /* Strings+Generated.swift */; };
 		64924A5A2BC499DD001E6C43 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 649249FF2BC499DD001E6C43 /* Localizable.strings */; };
@@ -100,6 +101,7 @@
 		640C29C42BD9F7870097D444 /* ResultsAvailabilityResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultsAvailabilityResource.swift; sourceTree = "<group>"; };
 		640C29C52BD9F7870097D444 /* ResultsResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultsResource.swift; sourceTree = "<group>"; };
 		640C29C72BD9F7870097D444 /* APIRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
+		640C29DB2BDA012D0097D444 /* FileManager+RemoveFileAtURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+RemoveFileAtURL.swift"; sourceTree = "<group>"; };
 		647635C028FBA34E0043DCFD /* Lumbly.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lumbly.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		649249FB2BC499DD001E6C43 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		649249FD2BC499DD001E6C43 /* Strings+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Strings+Generated.swift"; sourceTree = "<group>"; };
@@ -231,6 +233,14 @@
 				640C29C72BD9F7870097D444 /* APIRequest.swift */,
 			);
 			path = Requesting;
+			sourceTree = "<group>";
+		};
+		640C29D82BD9FF600097D444 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				640C29DB2BDA012D0097D444 /* FileManager+RemoveFileAtURL.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		647635B728FBA34E0043DCFD = {
@@ -582,6 +592,7 @@
 			children = (
 				64924A512BC499DD001E6C43 /* Sources */,
 				64924A022BC499DD001E6C43 /* Resources */,
+				640C29D82BD9FF600097D444 /* Extensions */,
 				64924A552BC499DD001E6C43 /* Supporting Files */,
 				64924A562BC499DD001E6C43 /* LumblyApp.swift */,
 			);
@@ -826,6 +837,7 @@
 				64924A672BC499DD001E6C43 /* CalendarTileView.swift in Sources */,
 				64924A5F2BC499DD001E6C43 /* ExerciseTipView.swift in Sources */,
 				64BB7C762BC4A04E0079226C /* SizeCalculator.swift in Sources */,
+				640C29DC2BDA012D0097D444 /* FileManager+RemoveFileAtURL.swift in Sources */,
 				64924A7C2BC499DD001E6C43 /* ResultsView.swift in Sources */,
 				64BB7C712BC4A04E0079226C /* StyledTextFieldView.swift in Sources */,
 				640C29D12BD9F7870097D444 /* HomeResource.swift in Sources */,

--- a/Lumbly/Extensions/FileManager+RemoveFileAtURL.swift
+++ b/Lumbly/Extensions/FileManager+RemoveFileAtURL.swift
@@ -1,0 +1,26 @@
+//
+//  FileManager+RemoveFileAtURL.swift
+//  Lumbly
+//
+//  Created by Yue chen Yu on 2024-04-24.
+//
+
+import Foundation
+
+extension FileManager {
+    func removeFile(atURL fileURL: URL?) {
+        guard let fileURL = fileURL,
+              self.fileExists(atPath: fileURL.path) else {
+            // TODO: Handle error
+            print("Url does not exist")
+            return
+        }
+
+        do {
+            try self.removeItem(atPath: fileURL.path)
+        } catch {
+            // TODO: Handle error
+            print("Error removing file at url: \(fileURL)")
+        }
+    }
+}

--- a/Lumbly/Sources/Features/Video/Playback/PlaybackView.swift
+++ b/Lumbly/Sources/Features/Video/Playback/PlaybackView.swift
@@ -48,7 +48,7 @@ struct PlaybackView: View {
                 }
                 .onDisappear {
                     if viewModel.recordingViewModel.isTestRun {
-                        viewModel.removeTemporaryVideo()
+                        FileManager.default.removeFile(atURL: videoFileURL)
                     }
                 }
                 .overlay(alignment: .top) {

--- a/Lumbly/Sources/Features/Video/Playback/PlaybackViewModel.swift
+++ b/Lumbly/Sources/Features/Video/Playback/PlaybackViewModel.swift
@@ -36,23 +36,7 @@ extension PlaybackView {
                 // TODO: Handle error
             }
 
-            removeTemporaryVideo()
-        }
-        
-        func removeTemporaryVideo() {
-            if let videoFileURL = videoFileURL {
-                let path = videoFileURL.path
-                
-                guard FileManager.default.fileExists(atPath: path) else { return }
-                
-                do {
-                    try FileManager.default.removeItem(atPath: path)
-                } catch {
-                    print("Error removing file at url: \(videoFileURL)")
-                }
-            } else {
-                print("Url does not exist")
-            }
+            FileManager.default.removeFile(atURL: videoFileURL)
         }
     }
 }


### PR DESCRIPTION
The previous `removeTemporaryVideo()` removed the video stored at the fileURL saved in the viewModel. With certain timings, this could cause the wrong video to be removed.

A new function was written to replace `removeTemporaryVideo()` that accepts the file URL as an input to ensure the correct video is removed.