### PR TITLE
Clean up RecordingViewModel variables

### DIFF
--- a/Lumbly/Sources/Features/ExerciseInstructions/ExerciseInstructionsView.swift
+++ b/Lumbly/Sources/Features/ExerciseInstructions/ExerciseInstructionsView.swift
@@ -103,10 +103,10 @@ struct ExerciseInstructionsView: View {
                         
                         NavigationLink(destination: RecordingView(viewModel:
                                 .init(isTestRun: viewModel.isTestRun,
+                                      parentView: self,
                                       parentExerciseSet: viewModel.parentExerciseSet,
                                       exerciseName: exerciseName,
-                                      recordingInfoModalBodyText: viewModel.exerciseInstructionsData?.recordingInfoModalBodyText,
-                                      parentView: self))) {
+                                      recordingInfoModalBodyText: viewModel.exerciseInstructionsData?.recordingInfoModalBodyText))) {
                             BlueButtonView(text: L10n.ExerciseInstructionsView.ready, navLinkButton: true)
                                 .frame(width: Constants.readyButtonWidth, height: Constants.readyButtonHeight, alignment: .bottom)
                         }

--- a/Lumbly/Sources/Features/Rating/PainRating/PainLevelRatingView.swift
+++ b/Lumbly/Sources/Features/Rating/PainRating/PainLevelRatingView.swift
@@ -56,13 +56,12 @@ struct PainLevelRatingView_Previews: PreviewProvider {
         PainLevelRatingView(viewModel:
                 .init(recordingViewModel:
                         .init(isTestRun: false,
-                              parentExerciseSet: "",
-                              exerciseName: "",
-                              recordingInfoModalBodyText: "",
-                              timestamp: nil,
                               parentView: .init(viewModel: .init(parentExerciseSet: "",
                                                                  exerciseNumber: 2,
                                                                  exerciseInstructionsURL: nil,
-                                                                 isTestRun: false)))))
+                                                                 isTestRun: false)),
+                              parentExerciseSet: "",
+                              exerciseName: "",
+                              recordingInfoModalBodyText: "")))
     }
 }

--- a/Lumbly/Sources/Features/Results/ResultsView.swift
+++ b/Lumbly/Sources/Features/Results/ResultsView.swift
@@ -190,13 +190,12 @@ struct ResultsView_Previews: PreviewProvider {
         ResultsView(viewModel:
                 .init(recordingViewModel:
                         .init(isTestRun: false,
-                              parentExerciseSet: "",
-                              exerciseName: "", 
-                              recordingInfoModalBodyText: "",
-                              timestamp: nil,
                               parentView: .init(viewModel: .init(parentExerciseSet: "",
                                                                  exerciseNumber: 2,
                                                                  exerciseInstructionsURL: nil,
-                                                                 isTestRun: false)))))
+                                                                 isTestRun: false)),
+                              parentExerciseSet: "",
+                              exerciseName: "", 
+                              recordingInfoModalBodyText: "")))
     }
 }

--- a/Lumbly/Sources/Features/Video/Playback/PlaybackView.swift
+++ b/Lumbly/Sources/Features/Video/Playback/PlaybackView.swift
@@ -15,21 +15,21 @@ struct PlaybackView: View {
     
     private var leftOptionDestination: RecordingView {
         let newViewModel = RecordingView.RecordingViewModel(isTestRun: false,
+                                                            parentView: viewModel.recordingViewModel.parentView,
                                                             parentExerciseSet: viewModel.recordingViewModel.parentExerciseSet,
                                                             exerciseName: viewModel.recordingViewModel.exerciseName,
                                                             recordingInfoModalBodyText: viewModel.recordingViewModel.recordingInfoModalBodyText,
-                                                            timestamp: viewModel.recordingViewModel.timestamp,
-                                                            parentView: viewModel.recordingViewModel.parentView)
+                                                            timestamp: viewModel.recordingViewModel.timestamp)
         return RecordingView(viewModel: newViewModel)
     }
     
     private var rightOptionDestination: RecordingView {
         let newViewModel = RecordingView.RecordingViewModel(isTestRun: true,
+                                                            parentView: viewModel.recordingViewModel.parentView,
                                                             parentExerciseSet: viewModel.recordingViewModel.parentExerciseSet,
                                                             exerciseName: viewModel.recordingViewModel.exerciseName,
                                                             recordingInfoModalBodyText: viewModel.recordingViewModel.recordingInfoModalBodyText,
-                                                            timestamp: viewModel.recordingViewModel.timestamp,
-                                                            parentView: viewModel.recordingViewModel.parentView)
+                                                            timestamp: viewModel.recordingViewModel.timestamp)
         return RecordingView(viewModel: newViewModel)
     }
     

--- a/Lumbly/Sources/Features/Video/Playback/PlaybackView.swift
+++ b/Lumbly/Sources/Features/Video/Playback/PlaybackView.swift
@@ -37,7 +37,7 @@ struct PlaybackView: View {
     @State var viewModel: PlaybackViewModel
     
     var body: some View {
-        if let videoFileURL = viewModel.videoFileURL {
+        if let videoFileURL = viewModel.recordingViewModel.videoFileURL {
             VideoPlayer(player: player)
                 .ignoresSafeArea()
                 .onAppear() {

--- a/Lumbly/Sources/Features/Video/Playback/PlaybackViewModel.swift
+++ b/Lumbly/Sources/Features/Video/Playback/PlaybackViewModel.swift
@@ -9,17 +9,14 @@ import SwiftUI
 
 extension PlaybackView {
     class PlaybackViewModel: ObservableObject {
-        private(set) var videoFileURL: URL?
-        
         @Published var recordingViewModel: RecordingView.RecordingViewModel
         
-        init(recordingViewModel: RecordingView.RecordingViewModel, videoFileURL: URL?) {
+        init(recordingViewModel: RecordingView.RecordingViewModel) {
             self.recordingViewModel = recordingViewModel
-            self.videoFileURL = videoFileURL
         }
         
         func uploadVideo() async {
-            guard let fileURL = videoFileURL else {
+            guard let fileURL = recordingViewModel.videoFileURL else {
                 // TODO: Handle error
                 return
             }
@@ -36,7 +33,7 @@ extension PlaybackView {
                 // TODO: Handle error
             }
 
-            FileManager.default.removeFile(atURL: videoFileURL)
+            FileManager.default.removeFile(atURL: fileURL)
         }
     }
 }

--- a/Lumbly/Sources/Features/Video/Recording/HostedRecordingViewController.swift
+++ b/Lumbly/Sources/Features/Video/Recording/HostedRecordingViewController.swift
@@ -10,8 +10,6 @@ import SwiftUI
 import Combine
 
 struct HostedRecordingViewController: UIViewControllerRepresentable {
-    let videoFileURL: Binding<URL?>
-
     var viewModel: Binding<RecordingView.RecordingViewModel>
     var viewControllerLink: RecordingViewControllerLink
     
@@ -27,11 +25,8 @@ struct HostedRecordingViewController: UIViewControllerRepresentable {
     }
     
     class Coordinator: RecordingViewControllerDelegate {
-        let videoFileURLBinding: Binding<URL?>
-        var viewModelBinding: Binding<RecordingView.RecordingViewModel>
-        
         private var cancellable: AnyCancellable?
-        
+        var viewModelBinding: Binding<RecordingView.RecordingViewModel>
         var viewController: RecordingViewControllerLinkable?
         
         var viewControllerLink: RecordingViewControllerLink? {
@@ -45,18 +40,17 @@ struct HostedRecordingViewController: UIViewControllerRepresentable {
             }
         }
         
-        init(videoFileURLBinding: Binding<URL?>, viewModelBinding: Binding<RecordingView.RecordingViewModel>) {
-            self.videoFileURLBinding = videoFileURLBinding
+        init(viewModelBinding: Binding<RecordingView.RecordingViewModel>) {
             self.viewModelBinding = viewModelBinding
         }
         
         func videoFileUrlSet(_ viewController: RecordingViewController, videoFileURL: URL, timestamp: String) {
-            videoFileURLBinding.wrappedValue = videoFileURL
+            viewModelBinding.videoFileURL.wrappedValue = videoFileURL
             viewModelBinding.timestamp.wrappedValue = timestamp
         }
     }
     
     func makeCoordinator() -> Coordinator {
-        return Coordinator(videoFileURLBinding: videoFileURL, viewModelBinding: viewModel)
+        return Coordinator(viewModelBinding: viewModel)
     }
 }

--- a/Lumbly/Sources/Features/Video/Recording/RecordingView.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingView.swift
@@ -48,12 +48,11 @@ struct RecordingView: View {
     
     @State private var isRecording = false
     @State var shouldPresentPlayback = false
-    @State var videoFileURL: URL? = nil
     @State var viewModel: RecordingViewModel
     
     var body: some View {
         ZStack {
-            HostedRecordingViewController(videoFileURL: $videoFileURL, viewModel: $viewModel, viewControllerLink: viewControllerLink)
+            HostedRecordingViewController(viewModel: $viewModel, viewControllerLink: viewControllerLink)
                 .ignoresSafeArea(.container, edges: .horizontal)
 
             HStack {
@@ -101,11 +100,7 @@ struct RecordingView: View {
                 .frame(width: Constants.recordingButtonSize, height: Constants.recordingButtonSize)
         }
         .navigationDestination(isPresented: $shouldPresentPlayback) {
-            if let videoFileURL = videoFileURL {
-                PlaybackView(viewModel:
-                        .init(recordingViewModel: viewModel,
-                              videoFileURL: videoFileURL))
-            }
+            PlaybackView(viewModel: .init(recordingViewModel: viewModel))
         }
     }
     

--- a/Lumbly/Sources/Features/Video/Recording/RecordingViewModel.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingViewModel.swift
@@ -9,13 +9,13 @@ import SwiftUI
 
 extension RecordingView {
     class RecordingViewModel: ObservableObject {
+        @Published private(set) var isTestRun: Bool
         @Published private(set) var parentExerciseSet: String
         @Published private(set) var exerciseName: String
         @Published private(set) var recordingInfoModalBodyText: String?
         
         @Published var videoFileURL: URL?
         @Published var timestamp: String?
-        @Published var isTestRun: Bool
         
         var parentView: ExerciseInstructionsView
         

--- a/Lumbly/Sources/Features/Video/Recording/RecordingViewModel.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingViewModel.swift
@@ -20,19 +20,19 @@ extension RecordingView {
         var parentView: ExerciseInstructionsView
         
         init(isTestRun: Bool,
+             parentView: ExerciseInstructionsView,
              parentExerciseSet: String,
              exerciseName: String,
-             videoFileURL: URL? = nil,
              recordingInfoModalBodyText: String? = nil,
-             timestamp: String? = nil,
-             parentView: ExerciseInstructionsView) {
+             videoFileURL: URL? = nil,
+             timestamp: String? = nil) {
             self.isTestRun = isTestRun
+            self.parentView = parentView
             self.parentExerciseSet = parentExerciseSet
             self.exerciseName = exerciseName
+            self.recordingInfoModalBodyText = recordingInfoModalBodyText
             self.videoFileURL = videoFileURL
             self.timestamp = timestamp
-            self.recordingInfoModalBodyText = recordingInfoModalBodyText
-            self.parentView = parentView
         }
     }
 }

--- a/Lumbly/Sources/Features/Video/Recording/RecordingViewModel.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingViewModel.swift
@@ -13,6 +13,7 @@ extension RecordingView {
         @Published private(set) var exerciseName: String
         @Published private(set) var recordingInfoModalBodyText: String?
         
+        @Published var videoFileURL: URL?
         @Published var timestamp: String?
         @Published var isTestRun: Bool
         
@@ -21,12 +22,14 @@ extension RecordingView {
         init(isTestRun: Bool,
              parentExerciseSet: String,
              exerciseName: String,
+             videoFileURL: URL? = nil,
              recordingInfoModalBodyText: String? = nil,
              timestamp: String? = nil,
              parentView: ExerciseInstructionsView) {
             self.isTestRun = isTestRun
             self.parentExerciseSet = parentExerciseSet
             self.exerciseName = exerciseName
+            self.videoFileURL = videoFileURL
             self.timestamp = timestamp
             self.recordingInfoModalBodyText = recordingInfoModalBodyText
             self.parentView = parentView


### PR DESCRIPTION
Add `videoFileURL` variable to `RecordingViewModel` and use in place of `videoFileURL` variables in `PlaybackViewModel`, `HostedRecordingViewController`, and `RecordingView`

Reorder lines of `RecordingViewModel` initializer to flow more logically