### PR TITLE
Move string literals in ProfileView

### DIFF
--- a/Lumbly/Resources/SwiftGen/Generated/Strings+Generated.swift
+++ b/Lumbly/Resources/SwiftGen/Generated/Strings+Generated.swift
@@ -129,6 +129,10 @@ internal enum L10n {
     /// No pain
     internal static let noPain = L10n.tr("Localizable", "PainLevelTileView.noPain", fallback: "No pain")
   }
+  internal enum ProfileView {
+    /// Profile
+    internal static let profile = L10n.tr("Localizable", "ProfileView.profile", fallback: "Profile")
+  }
   internal enum RecordingInfoModalView {
     /// TEST RUN
     internal static let testRun = L10n.tr("Localizable", "RecordingInfoModalView.testRun", fallback: "TEST RUN")

--- a/Lumbly/Resources/SwiftGen/Sources/Localizable.strings
+++ b/Lumbly/Resources/SwiftGen/Sources/Localizable.strings
@@ -38,6 +38,9 @@
 // MARK: ExerciseSetTileView
 "ExerciseSetTileView.start" = "Start";
 
+// MARK: ProfileView
+"ProfileView.profile" = "Profile";
+
 // MARK: ExerciseSetView
 "ExerciseSetView.startExerciseSet" = "Start Exercise Set";
 "ExerciseSetView.noExercises" = "There are no exercises to show for this exercise set.";

--- a/Lumbly/Sources/Features/Home/ProfileView.swift
+++ b/Lumbly/Sources/Features/Home/ProfileView.swift
@@ -19,7 +19,7 @@ struct ProfileView: View {
                 .ignoresSafeArea(edges: [.horizontal, .bottom])
             
             VStack(spacing: Constants.vStackSpacing) {
-                Text("Profile") // TODO: Add to L10n
+                Text(L10n.ProfileView.profile)
                     .font(.largeTitleBold)
                     .foregroundColor(.darkGray06)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/Lumbly/Sources/Features/Home/ProfileView.swift
+++ b/Lumbly/Sources/Features/Home/ProfileView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ProfileView: View {
     private struct Constants {
+        static let temporaryBodyText = "This will show information about the user's profile." // For demo purpoes, this view was not implemented
         static let vStackSpacing: CGFloat = 80.0
         static let topPadding: CGFloat = 40.0
     }
@@ -26,7 +27,7 @@ struct ProfileView: View {
                     .padding(.top, Constants.topPadding)
                     .padding(.horizontal, .mediumSpace)
                 
-                Text("This will show information about the user's profile.\n\n(This view is to be updated.)")
+                Text(Constants.temporaryBodyText)
                     .font(.bodyBold)
                     .foregroundColor(.blueCharcoal)
                     .multilineTextAlignment(.center)


### PR DESCRIPTION
Move the "Profile" string into `Localizable.strings` and move the temporary body text string literal into `ProfileView`'s `Constants` struct