### PR TITLE
Store and pass in `FileManager` instance used to store temporary video file during recording

### DIFF
--- a/Lumbly/Sources/Features/Video/Playback/PlaybackView.swift
+++ b/Lumbly/Sources/Features/Video/Playback/PlaybackView.swift
@@ -47,8 +47,9 @@ struct PlaybackView: View {
                     player.play()
                 }
                 .onDisappear {
-                    if viewModel.recordingViewModel.isTestRun {
-                        FileManager.default.removeFile(atURL: videoFileURL)
+                    if viewModel.recordingViewModel.isTestRun,
+                       let fileManager = viewModel.recordingViewModel.fileManager {
+                        fileManager.removeFile(atURL: videoFileURL)
                     }
                 }
                 .overlay(alignment: .top) {

--- a/Lumbly/Sources/Features/Video/Playback/PlaybackViewModel.swift
+++ b/Lumbly/Sources/Features/Video/Playback/PlaybackViewModel.swift
@@ -32,8 +32,10 @@ extension PlaybackView {
             } catch {
                 // TODO: Handle error
             }
-
-            FileManager.default.removeFile(atURL: fileURL)
+            
+            if let fileManager = recordingViewModel.fileManager {
+                fileManager.removeFile(atURL: fileURL)
+            }
         }
     }
 }

--- a/Lumbly/Sources/Features/Video/Recording/HostedRecordingViewController.swift
+++ b/Lumbly/Sources/Features/Video/Recording/HostedRecordingViewController.swift
@@ -44,7 +44,8 @@ struct HostedRecordingViewController: UIViewControllerRepresentable {
             self.viewModelBinding = viewModelBinding
         }
         
-        func videoFileUrlSet(_ viewController: RecordingViewController, videoFileURL: URL, timestamp: String) {
+        func videoFileUrlSet(_ viewController: RecordingViewController, fileManager: FileManager, videoFileURL: URL, timestamp: String) {
+            viewModelBinding.fileManager.wrappedValue = fileManager
             viewModelBinding.videoFileURL.wrappedValue = videoFileURL
             viewModelBinding.timestamp.wrappedValue = timestamp
         }

--- a/Lumbly/Sources/Features/Video/Recording/RecordingViewController.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingViewController.swift
@@ -147,7 +147,9 @@ extension RecordingViewController: RecordingViewControllerLinkable {
         
         let videoPreviewLayerOrientation = previewLayer.connection?.videoOrientation
         
-        sessionQueue.async {
+        sessionQueue.async { [weak self] in
+            guard let self = self else { return }
+            
             if UIDevice.current.isMultitaskingSupported {
                 self.backgroundRecordingID = UIApplication.shared.beginBackgroundTask(expirationHandler: nil)
             }

--- a/Lumbly/Sources/Features/Video/Recording/RecordingViewController.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingViewController.swift
@@ -168,7 +168,7 @@ extension RecordingViewController: RecordingViewControllerLinkable {
             let outputFileName = getCurrentDateString() + Constants.videoFileExtension
             let temporaryVideoURL = self.fileManager.temporaryDirectory.appendingPathComponent(outputFileName)
             
-            self.delegate?.videoFileUrlSet(self, videoFileURL: temporaryVideoURL, timestamp: outputFileName)
+            self.delegate?.videoFileUrlSet(self, fileManager: self.fileManager, videoFileURL: temporaryVideoURL, timestamp: outputFileName)
             self.movieFileOutput.startRecording(to: temporaryVideoURL, recordingDelegate: self)
         }
     }

--- a/Lumbly/Sources/Features/Video/Recording/RecordingViewController.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingViewController.swift
@@ -12,6 +12,7 @@ import UIKit
 class RecordingViewController: UIViewController, AVCaptureFileOutputRecordingDelegate {
     private let captureSession = AVCaptureSession()
     private let sessionQueue = DispatchQueue(label: "sessionQueue")
+    private let fileManager = FileManager.default
     
     private var movieFileOutput = AVCaptureMovieFileOutput()
     private var permissionGranted = false
@@ -165,7 +166,7 @@ extension RecordingViewController: RecordingViewControllerLinkable {
             
             /// Start recording video to a temporary file.
             let outputFileName = getCurrentDateString() + Constants.videoFileExtension
-            let temporaryVideoURL = FileManager.default.temporaryDirectory.appendingPathComponent(outputFileName)
+            let temporaryVideoURL = self.fileManager.temporaryDirectory.appendingPathComponent(outputFileName)
             
             self.delegate?.videoFileUrlSet(self, videoFileURL: temporaryVideoURL, timestamp: outputFileName)
             self.movieFileOutput.startRecording(to: temporaryVideoURL, recordingDelegate: self)

--- a/Lumbly/Sources/Features/Video/Recording/RecordingViewControllerDelegate.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingViewControllerDelegate.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol RecordingViewControllerDelegate: AnyObject {
-    func videoFileUrlSet(_ viewController: RecordingViewController, videoFileURL: URL, timestamp: String)
+    func videoFileUrlSet(_ viewController: RecordingViewController, fileManager: FileManager, videoFileURL: URL, timestamp: String)
 }

--- a/Lumbly/Sources/Features/Video/Recording/RecordingViewModel.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingViewModel.swift
@@ -18,6 +18,7 @@ extension RecordingView {
         @Published var timestamp: String?
         
         var parentView: ExerciseInstructionsView
+        var fileManager: FileManager? = nil
         
         init(isTestRun: Bool,
              parentView: ExerciseInstructionsView,


### PR DESCRIPTION
Instead of assuming it will be saved to `FileManager.default`, establish one source of truth when the video is recorded and pass this instance around where needed.