### PR TITLE
Update GifView so that the error state is shown instead of a blank space

### DIFF
--- a/LumblyCore/Components/GifView/GifView.swift
+++ b/LumblyCore/Components/GifView/GifView.swift
@@ -21,8 +21,8 @@ struct GifView: View {
                 ErrorLoadingContentView(errorText: L10n.ErrorLoadingContentView.contentError)
             }
         }
-        .task() {
-            await viewModel.fetchGifData()
+        .onAppear() {
+            viewModel.fetchGifData()
         }
     }
 }

--- a/LumblyCore/Components/GifView/GifViewModel.swift
+++ b/LumblyCore/Components/GifView/GifViewModel.swift
@@ -24,19 +24,18 @@ extension GifView {
             self.loadStatus = .unknown
         }
         
-        func fetchGifData() async {
+        @MainActor func fetchGifData() {
             guard let url = url else {
                 loadStatus = .failure
                 return
             }
             
-            guard let (gifData, _) = try? await URLSession.shared.data(from: url) else {
+            do {
+                self.gifData = try Data(contentsOf: url)
+                loadStatus = .success
+            } catch {
                 loadStatus = .failure
-                return
             }
-            
-            self.gifData = gifData
-            loadStatus = .success
         }
     }
 }


### PR DESCRIPTION
The error state was not showing when the gif could not be loaded; instead, there was a large blank space left in the view containing the `GifView`. This was changed to ensure that `ErrorLoadingContentView` is shown when the gif cannot be loaded.