### PR TITLE
Localize days of the week strings

### DIFF
--- a/Lumbly/Resources/Generated/Strings.swift
+++ b/Lumbly/Resources/Generated/Strings.swift
@@ -13,18 +13,32 @@ internal enum L10n {
   internal enum CalendarTileView {
     /// FRI
     internal static let fri = L10n.tr("Localizable", "CalendarTileView.fri", fallback: "FRI")
+    /// Friday
+    internal static let friday = L10n.tr("Localizable", "CalendarTileView.friday", fallback: "Friday")
     /// MON
     internal static let mon = L10n.tr("Localizable", "CalendarTileView.mon", fallback: "MON")
+    /// Monday
+    internal static let monday = L10n.tr("Localizable", "CalendarTileView.monday", fallback: "Monday")
     /// SAT
     internal static let sat = L10n.tr("Localizable", "CalendarTileView.sat", fallback: "SAT")
+    /// Saturday
+    internal static let saturday = L10n.tr("Localizable", "CalendarTileView.saturday", fallback: "Saturday")
     /// SUN
     internal static let sun = L10n.tr("Localizable", "CalendarTileView.sun", fallback: "SUN")
+    /// Sunday
+    internal static let sunday = L10n.tr("Localizable", "CalendarTileView.sunday", fallback: "Sunday")
     /// THU
     internal static let thu = L10n.tr("Localizable", "CalendarTileView.thu", fallback: "THU")
+    /// Thursday
+    internal static let thursday = L10n.tr("Localizable", "CalendarTileView.thursday", fallback: "Thursday")
     /// TUE
     internal static let tue = L10n.tr("Localizable", "CalendarTileView.tue", fallback: "TUE")
+    /// Tuesday
+    internal static let tuesday = L10n.tr("Localizable", "CalendarTileView.tuesday", fallback: "Tuesday")
     /// WED
     internal static let wed = L10n.tr("Localizable", "CalendarTileView.wed", fallback: "WED")
+    /// Wednesday
+    internal static let wednesday = L10n.tr("Localizable", "CalendarTileView.wednesday", fallback: "Wednesday")
   }
   internal enum ErrorLoadingContentView {
     /// Oops! This content could not be loaded.

--- a/Lumbly/Resources/Localizable.strings
+++ b/Lumbly/Resources/Localizable.strings
@@ -34,6 +34,13 @@
 "CalendarTileView.fri" = "FRI";
 "CalendarTileView.sat" = "SAT";
 "CalendarTileView.sun" = "SUN";
+"CalendarTileView.monday" = "Monday";
+"CalendarTileView.tuesday" = "Tuesday";
+"CalendarTileView.wednesday" = "Wednesday";
+"CalendarTileView.thursday" = "Thursday";
+"CalendarTileView.friday" = "Friday";
+"CalendarTileView.saturday" = "Saturday";
+"CalendarTileView.sunday" = "Sunday";
 
 // MARK: ExerciseSetTileView
 "ExerciseSetTileView.start" = "Start";

--- a/Lumbly/Sources/Features/Results/ResultsForDayView.swift
+++ b/Lumbly/Sources/Features/Results/ResultsForDayView.swift
@@ -39,7 +39,7 @@ struct ResultsForDayView: View {
     }
     
     func getDayOfWeek() -> String {
-        switch viewModel.dayOfWeek { // TODO: Add strings to L10n
+        switch viewModel.dayOfWeek {
         case L10n.CalendarTileView.mon:
             return L10n.CalendarTileView.monday
         case L10n.CalendarTileView.tue:

--- a/Lumbly/Sources/Features/Results/ResultsForDayView.swift
+++ b/Lumbly/Sources/Features/Results/ResultsForDayView.swift
@@ -41,19 +41,19 @@ struct ResultsForDayView: View {
     func getDayOfWeek() -> String {
         switch viewModel.dayOfWeek { // TODO: Add strings to L10n
         case L10n.CalendarTileView.mon:
-            return "Monday"
+            return L10n.CalendarTileView.monday
         case L10n.CalendarTileView.tue:
-            return "Tuesday"
+            return L10n.CalendarTileView.tuesday
         case L10n.CalendarTileView.wed:
-            return "Wednesday"
+            return L10n.CalendarTileView.wednesday
         case L10n.CalendarTileView.thu:
-            return "Thursday"
+            return L10n.CalendarTileView.thursday
         case L10n.CalendarTileView.fri:
-            return "Friday"
+            return L10n.CalendarTileView.friday
         case L10n.CalendarTileView.sat:
-            return "Saturday"
+            return L10n.CalendarTileView.saturday
         case L10n.CalendarTileView.sun:
-            return "Sunday"
+            return L10n.CalendarTileView.sunday
         default:
             return ""
         }

--- a/Lumbly/Sources/Features/Results/ResultsForDayView.swift
+++ b/Lumbly/Sources/Features/Results/ResultsForDayView.swift
@@ -61,9 +61,9 @@ struct ResultsForDayView: View {
     
     func getContentString() -> String {
         if viewModel.didExercise {
-            return "This will show a list of exercise sets that you completed on the selected day.\n\n(This view is to be updated.)"
+            return "This will show a list of exercise sets that you completed on the selected day.\n\n(This view is to be updated.)" // Placeholder for demo purposes
         } else {
-            return "No exercises were completed on this day.\n\n(This view is to be updated.)"
+            return "No exercises were completed on this day.\n\n(This view is to be updated.)" // Placeholder for demo purposes
         }
     }
 }


### PR DESCRIPTION
Used localized strings for the full names of the days of the week, instead of the current string literals