### PR TITLE
Fix timestamp saving in `RecordingViewController`

### DIFF
--- a/Lumbly/Sources/Features/Video/Recording/RecordingViewController.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingViewController.swift
@@ -167,10 +167,11 @@ extension RecordingViewController: RecordingViewControllerLinkable {
             }
             
             /// Start recording video to a temporary file.
-            let outputFileName = getCurrentDateString() + Constants.videoFileExtension
+            let timestamp = getCurrentDateString()
+            let outputFileName = timestamp + Constants.videoFileExtension
             let temporaryVideoURL = self.fileManager.temporaryDirectory.appendingPathComponent(outputFileName)
             
-            self.delegate?.videoFileUrlSet(self, fileManager: self.fileManager, videoFileURL: temporaryVideoURL, timestamp: outputFileName)
+            self.delegate?.videoFileUrlSet(self, fileManager: self.fileManager, videoFileURL: temporaryVideoURL, timestamp: timestamp)
             self.movieFileOutput.startRecording(to: temporaryVideoURL, recordingDelegate: self)
         }
     }


### PR DESCRIPTION
Do not include video file extension when saving timestamp