### PR TITLE
Update StyledTextFieldView to have more control through its initializer

### DIFF
--- a/Lumbly/Sources/Features/Onboarding/Login/LoginView.swift
+++ b/Lumbly/Sources/Features/Onboarding/Login/LoginView.swift
@@ -32,17 +32,14 @@ struct LoginView: View {
                     .aspectRatio(contentMode: .fit)
                     .frame(width: Constants.logoWidth, height: Constants.logoHeight)
                 
-                StyledTextFieldView(textFieldContent:
-                                        AnyView(TextField(L10n.Onboarding.email,
-                                                          text: $email)
-                                            .textInputAutocapitalization(.never)
-                                            .autocorrectionDisabled(true)))
+                StyledTextFieldView(L10n.Onboarding.email,
+                                    text: $email,
+                                    autocorrectionDisabled: true)
                 
-                StyledTextFieldView(textFieldContent:
-                                        AnyView(SecureField(L10n.Onboarding.password,
-                                                            text: $password)
-                                            .textInputAutocapitalization(.never)
-                                            .autocorrectionDisabled(true)))
+                StyledTextFieldView(L10n.Onboarding.password,
+                                    text: $password,
+                                    autocorrectionDisabled: true,
+                                    isSecureField: true)
                 
                 NavigationLink(destination: HomeView()) {
                     BlueButtonView(text: L10n.Onboarding.logIn,

--- a/Lumbly/Sources/Features/Onboarding/Signup/SignupView.swift
+++ b/Lumbly/Sources/Features/Onboarding/Signup/SignupView.swift
@@ -37,29 +37,22 @@ struct SignupView: View {
                         .frame(width: Constants.logoWidth, height: Constants.logoHeight)
                         .padding(.top, Constants.topPadding)
                     
-                    StyledTextFieldView(textFieldContent:
-                                            AnyView(TextField(L10n.Onboarding.physiotherapistCode,
-                                                              text: $physiotherapistCode)
-                                                .textInputAutocapitalization(.never)
-                                                .autocorrectionDisabled(true)))
+                    StyledTextFieldView(L10n.Onboarding.physiotherapistCode,
+                                        text: $physiotherapistCode,
+                                        autocorrectionDisabled: true)
                     
-                    StyledTextFieldView(textFieldContent:
-                                            AnyView(TextField(L10n.Onboarding.name,
-                                                              text: $name)
-                                                .textInputAutocapitalization(.never)
-                                                .autocorrectionDisabled(true)))
+                    StyledTextFieldView(L10n.Onboarding.name,
+                                        text: $name,
+                                        autocorrectionDisabled: true)
                     
-                    StyledTextFieldView(textFieldContent:
-                                            AnyView(TextField(L10n.Onboarding.email,
-                                                              text: $email)
-                                                .textInputAutocapitalization(.never)
-                                                .autocorrectionDisabled(true)))
+                    StyledTextFieldView(L10n.Onboarding.email,
+                                        text: $email,
+                                        autocorrectionDisabled: true)
                     
-                    StyledTextFieldView(textFieldContent:
-                                            AnyView(SecureField(L10n.Onboarding.password,
-                                                                text: $password)
-                                                .textInputAutocapitalization(.never)
-                                                .autocorrectionDisabled(true)))
+                    StyledTextFieldView(L10n.Onboarding.password,
+                                        text: $password,
+                                        autocorrectionDisabled: true,
+                                        isSecureField: true)
                     
                     NavigationLink(destination: HomeView()) {
                         BlueButtonView(text: L10n.Onboarding.signUp,

--- a/LumblyCore/Components/StyledTextFieldView.swift
+++ b/LumblyCore/Components/StyledTextFieldView.swift
@@ -8,42 +8,39 @@
 import SwiftUI
 
 struct StyledTextFieldView: View {
-    private struct Constants {
-        static let fieldHeight: CGFloat = 56.0
-    }
+    @Binding var text: String
     
-    var textFieldContent: AnyView
+    var title: String
+    var autocapitalization: TextInputAutocapitalization
+    var autocorrectionDisabled: Bool
+    var backgroundColor: Color
+    var isSecureField: Bool
+    
+    init(_ title: String = "",
+         text: Binding<String>,
+         autocapitalization: TextInputAutocapitalization = .never,
+         autocorrectionDisabled: Bool = false,
+         backgroundColor: Color = .white,
+         isSecureField: Bool = false) {
+        self.title = title
+        self._text = text
+        self.autocapitalization = autocapitalization
+        self.autocorrectionDisabled = autocorrectionDisabled
+        self.backgroundColor = backgroundColor
+        self.isSecureField = isSecureField
+    }
     
     var body: some View {
-        ZStack {
-            Rectangle()
-                .fill(.white)
-            
-            VStack {
-                textFieldContent
-                
-                Divider()
-            }.padding(.horizontal, .smallSpace)
-        }.frame(height: Constants.fieldHeight)
-    }
-}
-
-
-struct TextFieldStylingView_Previews: PreviewProvider {
-    static var previews: some View {
-        ZStack {
-            Color.oysterBay
-                .ignoresSafeArea(.all)
-            
-            VStack {
-                StyledTextFieldView(textFieldContent: AnyView(TextField("Email", text: .constant(""))))
-                
-                StyledTextFieldView(textFieldContent:
-                                        AnyView(TextField(L10n.Onboarding.physiotherapistCode,
-                                                          text: .constant(""))
-                                            .textInputAutocapitalization(.never)
-                                            .autocorrectionDisabled(true)))
+        Group {
+            if isSecureField {
+                SecureField(title, text: $text)
+            } else {
+                TextField(title, text: $text, axis: .vertical)
             }
         }
+        .textInputAutocapitalization(autocapitalization)
+        .autocorrectionDisabled(autocorrectionDisabled)
+        .padding(.all, .smallSpace)
+        .background(backgroundColor)
     }
 }


### PR DESCRIPTION
Rewrite `StyledTextFieldView` to create a `SecureField` or a `TextField` and apply modifiers based on parameters in its initializer, instead of simply passing in an `AnyView` (which was assumed to be a `TextField`).

Modify calls to the `StyledTextFieldView` initializer as applicable.