### PR TITLE
Add more customization to `StyledTextFieldView`

### DIFF
--- a/Lumbly/Sources/Features/Onboarding/Signup/SignupView.swift
+++ b/Lumbly/Sources/Features/Onboarding/Signup/SignupView.swift
@@ -9,14 +9,13 @@ import SwiftUI
 
 struct SignupView: View {
     private struct Constants {
-        static let topPadding: CGFloat = 40.0
         static let logoWidth: CGFloat = 282.0
         static let logoHeight: CGFloat = 103.0
-        static let fieldHeight: CGFloat = 56.0
         static let buttonWidth: CGFloat = 177.0
         static let buttonHeight: CGFloat = 56.0
         static let vStackSpacing: CGFloat = 40.0
-        static let vStackHorizontalPadding: CGFloat = 20.0
+        static let horizontalPadding: CGFloat = 20.0
+        static let verticalPadding: CGFloat = 40.0
     }
     
     @State private var physiotherapistCode: String = ""
@@ -35,7 +34,6 @@ struct SignupView: View {
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: Constants.logoWidth, height: Constants.logoHeight)
-                        .padding(.top, Constants.topPadding)
                     
                     StyledTextFieldView(viewModel:
                             .init(L10n.Onboarding.physiotherapistCode,
@@ -67,7 +65,9 @@ struct SignupView: View {
                                name.isEmpty ||
                                email.isEmpty ||
                                password.isEmpty)
-                }.padding(.horizontal, Constants.vStackHorizontalPadding)
+                }
+                .padding(.horizontal, Constants.horizontalPadding)
+                .padding(.vertical, Constants.verticalPadding)
             }
         }
     }

--- a/LumblyCore/Components/StyledTextField/StyledTextFieldView.swift
+++ b/LumblyCore/Components/StyledTextField/StyledTextFieldView.swift
@@ -20,7 +20,7 @@ struct StyledTextFieldView: View {
             if viewModel.isSecureField {
                 SecureField(styledTitle, text: viewModel.$text)
             } else {
-                TextField(styledTitle, text: viewModel.$text, axis: .vertical)
+                TextField(styledTitle, text: viewModel.$text, axis: viewModel.axis)
             }
         }
         .textInputAutocapitalization(viewModel.autocapitalization)

--- a/LumblyCore/Components/StyledTextField/StyledTextFieldView.swift
+++ b/LumblyCore/Components/StyledTextField/StyledTextFieldView.swift
@@ -8,14 +8,19 @@
 import SwiftUI
 
 struct StyledTextFieldView: View {
+    private var styledTitle: String {
+        let suffix = viewModel.isRequiredField ? "*" : ""
+        return viewModel.title + suffix
+    }
+    
     @StateObject var viewModel: StyledTextFieldViewModel
     
     var body: some View {
         Group {
             if viewModel.isSecureField {
-                SecureField(viewModel.title, text: viewModel.$text)
+                SecureField(styledTitle, text: viewModel.$text)
             } else {
-                TextField(viewModel.title, text: viewModel.$text, axis: .vertical)
+                TextField(styledTitle, text: viewModel.$text, axis: .vertical)
             }
         }
         .textInputAutocapitalization(viewModel.autocapitalization)

--- a/LumblyCore/Components/StyledTextField/StyledTextFieldViewModel.swift
+++ b/LumblyCore/Components/StyledTextField/StyledTextFieldViewModel.swift
@@ -16,6 +16,7 @@ extension StyledTextFieldView {
         private(set) var autocapitalization: TextInputAutocapitalization
         private(set) var autocorrectionDisabled: Bool
         private(set) var backgroundColor: Color
+        private(set) var axis: Axis
         private(set) var isSecureField: Bool
         
         init(_ title: String = "",
@@ -24,6 +25,7 @@ extension StyledTextFieldView {
              autocapitalization: TextInputAutocapitalization = .never,
              autocorrectionDisabled: Bool = false,
              backgroundColor: Color = .white,
+             axis: Axis = .horizontal,
              isSecureField: Bool = false) {
             self.title = title
             self._text = text
@@ -31,6 +33,7 @@ extension StyledTextFieldView {
             self.autocapitalization = autocapitalization
             self.autocorrectionDisabled = autocorrectionDisabled
             self.backgroundColor = backgroundColor
+            self.axis = axis
             self.isSecureField = isSecureField
         }
     }

--- a/LumblyCore/Components/StyledTextField/StyledTextFieldViewModel.swift
+++ b/LumblyCore/Components/StyledTextField/StyledTextFieldViewModel.swift
@@ -12,6 +12,7 @@ extension StyledTextFieldView {
         @Binding var text: String
         
         private(set) var title: String
+        private(set) var isRequiredField: Bool
         private(set) var autocapitalization: TextInputAutocapitalization
         private(set) var autocorrectionDisabled: Bool
         private(set) var backgroundColor: Color
@@ -19,12 +20,14 @@ extension StyledTextFieldView {
         
         init(_ title: String = "",
              text: Binding<String>,
+             isRequiredField: Bool = true,
              autocapitalization: TextInputAutocapitalization = .never,
              autocorrectionDisabled: Bool = false,
              backgroundColor: Color = .white,
              isSecureField: Bool = false) {
             self.title = title
             self._text = text
+            self.isRequiredField = isRequiredField
             self.autocapitalization = autocapitalization
             self.autocorrectionDisabled = autocorrectionDisabled
             self.backgroundColor = backgroundColor


### PR DESCRIPTION
Added `isRequiredField` to `StyledTextFieldViewModel` to append "*" to the title of required fields.
Added `axis` to `StyledTextFieldViewModel` to set the text field's axis based on the viewModel (default is `.horizontal` if not specified), instead of defaulting to `.vertical`.