### PR TITLE
Rename all view models to `ViewModel` by removing view-specific prefix

### DIFF
--- a/Lumbly/Sources/Features/Error/ErrorView.swift
+++ b/Lumbly/Sources/Features/Error/ErrorView.swift
@@ -13,7 +13,7 @@ struct ErrorView: View {
         static let topPadding: CGFloat = 40.0
     }
     
-    var viewModel: ErrorViewModel
+    var viewModel: ViewModel
     
     var body: some View {
         VStack(spacing: Constants.vStackSpacing) {

--- a/Lumbly/Sources/Features/Error/ErrorViewModel.swift
+++ b/Lumbly/Sources/Features/Error/ErrorViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension ErrorView {
-    class ErrorViewModel {
+    class ViewModel {
         var header: String?
         var errorText: String
         

--- a/Lumbly/Sources/Features/ExerciseInstructions/ExerciseInstructionsView.swift
+++ b/Lumbly/Sources/Features/ExerciseInstructions/ExerciseInstructionsView.swift
@@ -25,7 +25,7 @@ struct ExerciseInstructionsView: View {
     
     @State private var stepsOrTips: PickerState = .steps
 
-    @StateObject var viewModel: ExerciseInstructionsViewModel
+    @StateObject var viewModel: ViewModel
 
     var body: some View {
         ZStack {

--- a/Lumbly/Sources/Features/ExerciseInstructions/ExerciseInstructionsViewModel.swift
+++ b/Lumbly/Sources/Features/ExerciseInstructions/ExerciseInstructionsViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension ExerciseInstructionsView {
-    class ExerciseInstructionsViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         @Published private(set) var exerciseInstructionsData: ExerciseInstructions? = nil
         @Published private(set) var isLoading: Bool = false
         

--- a/Lumbly/Sources/Features/ExerciseInstructions/ExerciseStep/ExerciseStepView.swift
+++ b/Lumbly/Sources/Features/ExerciseInstructions/ExerciseStep/ExerciseStepView.swift
@@ -14,7 +14,7 @@ struct ExerciseStepView: View {
         static let imageHeight: CGFloat = 148.0
     }
     
-    @StateObject var viewModel: ExerciseStepViewModel
+    @StateObject var viewModel: ViewModel
     
     var body: some View {
         VStack(spacing: .smallSpace) {

--- a/Lumbly/Sources/Features/ExerciseInstructions/ExerciseStep/ExerciseStepViewModel.swift
+++ b/Lumbly/Sources/Features/ExerciseInstructions/ExerciseStep/ExerciseStepViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension ExerciseStepView {
-    class ExerciseStepViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         @Published private(set) var exerciseStepData: ExerciseStep?
         
         init(exerciseStepData: ExerciseStep?) {

--- a/Lumbly/Sources/Features/ExerciseInstructions/ExerciseTip/ExerciseTipView.swift
+++ b/Lumbly/Sources/Features/ExerciseInstructions/ExerciseTip/ExerciseTipView.swift
@@ -16,7 +16,7 @@ struct ExerciseTipView: View {
         static let tileCornerRadius: CGFloat = 15.0
     }
     
-    @StateObject var viewModel: ExerciseTipViewModel
+    @StateObject var viewModel: ViewModel
     
     var body: some View {
         VStack(spacing: Constants.textAndImageSpacing) {

--- a/Lumbly/Sources/Features/ExerciseInstructions/ExerciseTip/ExerciseTipViewModel.swift
+++ b/Lumbly/Sources/Features/ExerciseInstructions/ExerciseTip/ExerciseTipViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension ExerciseTipView {
-    class ExerciseTipViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         @Published private(set) var tipNumber: Int?
         @Published private(set) var exerciseTipData: ExerciseTip?
         

--- a/Lumbly/Sources/Features/ExerciseSet/ExerciseSetView.swift
+++ b/Lumbly/Sources/Features/ExerciseSet/ExerciseSetView.swift
@@ -16,7 +16,7 @@ struct ExerciseSetView: View {
         static let bottomPadding: CGFloat = 80.0
     }
     
-    @StateObject var viewModel: ExerciseSetViewModel
+    @StateObject var viewModel: ViewModel
     
     var body: some View {
         ZStack {

--- a/Lumbly/Sources/Features/ExerciseSet/ExerciseSetViewModel.swift
+++ b/Lumbly/Sources/Features/ExerciseSet/ExerciseSetViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension ExerciseSetView {
-    class ExerciseSetViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         @Published private(set) var exerciseSetData: ExerciseSet? = nil
         @Published var isLoading: Bool = false
         

--- a/Lumbly/Sources/Features/ExerciseSet/ExerciseTile/ExerciseTileView.swift
+++ b/Lumbly/Sources/Features/ExerciseSet/ExerciseTile/ExerciseTileView.swift
@@ -16,7 +16,7 @@ struct ExerciseTileView: View {
         static let exerciseImageHeight: CGFloat = 78.0
     }
     
-    @StateObject var viewModel: ExerciseTileViewModel
+    @StateObject var viewModel: ViewModel
     
     var body: some View {
         ZStack {

--- a/Lumbly/Sources/Features/ExerciseSet/ExerciseTile/ExerciseTileViewModel.swift
+++ b/Lumbly/Sources/Features/ExerciseSet/ExerciseTile/ExerciseTileViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension ExerciseTileView {
-    class ExerciseTileViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         @Published private(set) var exerciseTileData: ExerciseTile?
         
         init(exerciseTileData: ExerciseTile?) {

--- a/Lumbly/Sources/Features/Home/CalendarTile/CalendarTileView.swift
+++ b/Lumbly/Sources/Features/Home/CalendarTile/CalendarTileView.swift
@@ -15,7 +15,7 @@ struct CalendarTileView: View {
         static let circleSize: CGFloat = 6.0
     }
     
-    @StateObject var viewModel: CalendarTileViewModel
+    @StateObject var viewModel: ViewModel
     
     var body: some View {
         ZStack {
@@ -61,7 +61,7 @@ struct CalendarTileView: View {
         }
     }
     
-    func getColors(dateRelativeToToday: CalendarTileViewModel.DateRelativeToToday?) -> (tileColor: Color?, borderColor: Color?, accentColor: Color?) {
+    func getColors(dateRelativeToToday: ViewModel.DateRelativeToToday?) -> (tileColor: Color?, borderColor: Color?, accentColor: Color?) {
         if let dateRelativeToToday = dateRelativeToToday {
             switch(dateRelativeToToday) {
             case .past:

--- a/Lumbly/Sources/Features/Home/CalendarTile/CalendarTileViewModel.swift
+++ b/Lumbly/Sources/Features/Home/CalendarTile/CalendarTileViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension CalendarTileView {
-    class CalendarTileViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         enum DateRelativeToToday {
             case past
             case today

--- a/Lumbly/Sources/Features/Home/ExerciseSetTile/ExerciseSetTileView.swift
+++ b/Lumbly/Sources/Features/Home/ExerciseSetTile/ExerciseSetTileView.swift
@@ -13,7 +13,7 @@ struct ExerciseSetTileView: View {
         static let topPadding: CGFloat = 28.0
     }
     
-    @StateObject var viewModel: ExerciseSetTileViewModel
+    @StateObject var viewModel: ViewModel
     
     var body: some View {
         ZStack {

--- a/Lumbly/Sources/Features/Home/ExerciseSetTile/ExerciseSetTileViewModel.swift
+++ b/Lumbly/Sources/Features/Home/ExerciseSetTile/ExerciseSetTileViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension ExerciseSetTileView {
-    class ExerciseSetTileViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         @Published private(set) var exerciseSetTileData: ExerciseSetTile?
         
         init(exerciseSetTileData: ExerciseSetTile?) {

--- a/Lumbly/Sources/Features/Home/HomeView.swift
+++ b/Lumbly/Sources/Features/Home/HomeView.swift
@@ -22,7 +22,7 @@ struct HomeView: View {
         static let calendarTilesHeight: CGFloat = 100.0
     }
     
-    @StateObject private var viewModel = HomeViewModel()
+    @StateObject private var viewModel = ViewModel()
     
     @State private var navigationBarHidden: Bool = true
 

--- a/Lumbly/Sources/Features/Home/HomeViewModel.swift
+++ b/Lumbly/Sources/Features/Home/HomeViewModel.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 extension HomeView {
-    class HomeViewModel: ObservableObject {
-        typealias RelativeDate = CalendarTileView.CalendarTileViewModel.DateRelativeToToday
+    class ViewModel: ObservableObject {
+        typealias RelativeDate = CalendarTileView.ViewModel.DateRelativeToToday
         
         @Published private(set) var homeData: Home? = nil
         @Published private(set) var isLoading: Bool = false

--- a/Lumbly/Sources/Features/Onboarding/Signup/SignupView.swift
+++ b/Lumbly/Sources/Features/Onboarding/Signup/SignupView.swift
@@ -18,7 +18,7 @@ struct SignupView: View {
         static let verticalPadding: CGFloat = 40.0
     }
     
-    private var styledTextFieldViewModels: [StyledTextFieldView.StyledTextFieldViewModel] {
+    private var styledTextFieldViewModels: [StyledTextFieldView.ViewModel] {
         return [.init(L10n.Onboarding.physiotherapistCode,
                       text: $physiotherapistCode,
                       autocorrectionDisabled: true),

--- a/Lumbly/Sources/Features/Rating/ExerciseRatingTile/ExerciseRatingTileView.swift
+++ b/Lumbly/Sources/Features/Rating/ExerciseRatingTile/ExerciseRatingTileView.swift
@@ -18,7 +18,7 @@ struct ExerciseRatingTileView: View {
         static let imageSize: CGFloat = 33.38
     }
     
-    @StateObject var viewModel: ExerciseRatingTileViewModel
+    @StateObject var viewModel: ViewModel
     
     var body: some View {
         ZStack {

--- a/Lumbly/Sources/Features/Rating/ExerciseRatingTile/ExerciseRatingTileViewModel.swift
+++ b/Lumbly/Sources/Features/Rating/ExerciseRatingTile/ExerciseRatingTileViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension ExerciseRatingTileView {
-    class ExerciseRatingTileViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         @Published private(set) var exerciseRating: String?
         
         init(exerciseRating: String?) {

--- a/Lumbly/Sources/Features/Rating/PainRating/PainLevelRatingView.swift
+++ b/Lumbly/Sources/Features/Rating/PainRating/PainLevelRatingView.swift
@@ -17,7 +17,7 @@ struct PainLevelRatingView: View {
                           GridItem(.fixed(Constants.tileWidth), spacing: .mediumSpace),
                           GridItem(.fixed(Constants.tileWidth), spacing: .mediumSpace)]
     
-    @StateObject var viewModel: PainLevelRatingViewModel
+    @StateObject var viewModel: ViewModel
     
     var body: some View {
         // TODO: Change to navigate to exercise rating view

--- a/Lumbly/Sources/Features/Rating/PainRating/PainLevelRatingViewModel.swift
+++ b/Lumbly/Sources/Features/Rating/PainRating/PainLevelRatingViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension PainLevelRatingView {
-    class PainLevelRatingViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         let painLevelOptions: [String] = [L10n.PainLevelTileView.noPain,
                                           L10n.PainLevelTileView.hurtsALittle,
                                           L10n.PainLevelTileView.hurtsALittleMore,
@@ -16,9 +16,9 @@ extension PainLevelRatingView {
                                           L10n.PainLevelTileView.hurtsAWholeLot,
                                           L10n.PainLevelTileView.hurtsTheWorst]
         
-        var recordingViewModel: RecordingView.RecordingViewModel
+        var recordingViewModel: RecordingView.ViewModel
         
-        init(recordingViewModel: RecordingView.RecordingViewModel) {
+        init(recordingViewModel: RecordingView.ViewModel) {
             self.recordingViewModel = recordingViewModel
         }
         

--- a/Lumbly/Sources/Features/Rating/PainRating/PainLevelTile/PainLevelTileView.swift
+++ b/Lumbly/Sources/Features/Rating/PainRating/PainLevelTile/PainLevelTileView.swift
@@ -18,7 +18,7 @@ struct PainLevelTileView: View {
         static let faceSize: CGFloat = 28.0
     }
     
-    @StateObject var viewModel: PainLevelTileViewModel
+    @StateObject var viewModel: ViewModel
 
     var body: some View {
         ZStack {

--- a/Lumbly/Sources/Features/Rating/PainRating/PainLevelTile/PainLevelTileViewModel.swift
+++ b/Lumbly/Sources/Features/Rating/PainRating/PainLevelTile/PainLevelTileViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension PainLevelTileView {
-    class PainLevelTileViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         @Published private(set) var painLevel: String?
         
         init(painLevel: String?) {

--- a/Lumbly/Sources/Features/Results/FormCommentTile/FormCommentTileView.swift
+++ b/Lumbly/Sources/Features/Results/FormCommentTile/FormCommentTileView.swift
@@ -16,7 +16,7 @@ struct FormCommentTileView: View {
         static let tileCornerRadius: CGFloat = 10.0
     }
     
-    @StateObject var viewModel: FormCommentTileViewModel
+    @StateObject var viewModel: ViewModel
     
     var body: some View {
         VStack(alignment: .leading, spacing: Constants.commentSolutionSpacing) {

--- a/Lumbly/Sources/Features/Results/FormCommentTile/FormCommentTileViewModel.swift
+++ b/Lumbly/Sources/Features/Results/FormCommentTile/FormCommentTileViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension FormCommentTileView {
-    class FormCommentTileViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         @Published private(set) var formCommentTileData: FormCommentTile?
         var isFormMistake: Bool
 

--- a/Lumbly/Sources/Features/Results/ResultsForDay/ResultsForDayView.swift
+++ b/Lumbly/Sources/Features/Results/ResultsForDay/ResultsForDayView.swift
@@ -13,7 +13,7 @@ struct ResultsForDayView: View {
         static let topPadding: CGFloat = 40.0
     }
 
-    var viewModel: ResultsForDayViewModel
+    var viewModel: ViewModel
 
     var body: some View {
         ZStack {

--- a/Lumbly/Sources/Features/Results/ResultsForDay/ResultsForDayViewModel.swift
+++ b/Lumbly/Sources/Features/Results/ResultsForDay/ResultsForDayViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension ResultsForDayView {
-    class ResultsForDayViewModel {
+    class ViewModel {
         var dayOfWeek: String
         var didExercise: Bool
         

--- a/Lumbly/Sources/Features/Results/ResultsView.swift
+++ b/Lumbly/Sources/Features/Results/ResultsView.swift
@@ -21,7 +21,7 @@ struct ResultsView: View {
     }
     
     @State private var selectedExercise: Int = 0
-    @StateObject var viewModel: ResultsViewModel
+    @StateObject var viewModel: ViewModel
     
     var body: some View {
         ZStack {

--- a/Lumbly/Sources/Features/Results/ResultsViewModel.swift
+++ b/Lumbly/Sources/Features/Results/ResultsViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension ResultsView {
-    class ResultsViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         private struct Constants {
             static let requestDelay: Double = 1.0
             static let requestLeeway: DispatchTimeInterval = .milliseconds(50)
@@ -18,9 +18,9 @@ extension ResultsView {
         @Published private(set) var isLoading: Bool = false
         @Published private(set) var resultsAvailability: ResultsAvailability = ResultsAvailability(status: .unknown)
         
-        private var recordingViewModel: RecordingView.RecordingViewModel
+        private var recordingViewModel: RecordingView.ViewModel
         
-        init(recordingViewModel: RecordingView.RecordingViewModel) {
+        init(recordingViewModel: RecordingView.ViewModel) {
             self.recordingViewModel = recordingViewModel
         }
 

--- a/Lumbly/Sources/Features/Video/Playback/PlaybackView.swift
+++ b/Lumbly/Sources/Features/Video/Playback/PlaybackView.swift
@@ -14,27 +14,27 @@ struct PlaybackView: View {
     }
     
     private var leftOptionDestination: RecordingView {
-        let newViewModel = RecordingView.RecordingViewModel(isTestRun: false,
-                                                            parentView: viewModel.recordingViewModel.parentView,
-                                                            parentExerciseSet: viewModel.recordingViewModel.parentExerciseSet,
-                                                            exerciseName: viewModel.recordingViewModel.exerciseName,
-                                                            recordingInfoModalBodyText: viewModel.recordingViewModel.recordingInfoModalBodyText,
-                                                            timestamp: viewModel.recordingViewModel.timestamp)
+        let newViewModel = RecordingView.ViewModel(isTestRun: false,
+                                                   parentView: viewModel.recordingViewModel.parentView,
+                                                   parentExerciseSet: viewModel.recordingViewModel.parentExerciseSet,
+                                                   exerciseName: viewModel.recordingViewModel.exerciseName,
+                                                   recordingInfoModalBodyText: viewModel.recordingViewModel.recordingInfoModalBodyText,
+                                                   timestamp: viewModel.recordingViewModel.timestamp)
         return RecordingView(viewModel: newViewModel)
     }
     
     private var rightOptionDestination: RecordingView {
-        let newViewModel = RecordingView.RecordingViewModel(isTestRun: true,
-                                                            parentView: viewModel.recordingViewModel.parentView,
-                                                            parentExerciseSet: viewModel.recordingViewModel.parentExerciseSet,
-                                                            exerciseName: viewModel.recordingViewModel.exerciseName,
-                                                            recordingInfoModalBodyText: viewModel.recordingViewModel.recordingInfoModalBodyText,
-                                                            timestamp: viewModel.recordingViewModel.timestamp)
+        let newViewModel = RecordingView.ViewModel(isTestRun: true,
+                                                   parentView: viewModel.recordingViewModel.parentView,
+                                                   parentExerciseSet: viewModel.recordingViewModel.parentExerciseSet,
+                                                   exerciseName: viewModel.recordingViewModel.exerciseName,
+                                                   recordingInfoModalBodyText: viewModel.recordingViewModel.recordingInfoModalBodyText,
+                                                   timestamp: viewModel.recordingViewModel.timestamp)
         return RecordingView(viewModel: newViewModel)
     }
     
     @State private var player = AVPlayer()
-    @State var viewModel: PlaybackViewModel
+    @State var viewModel: ViewModel
     
     var body: some View {
         if let videoFileURL = viewModel.recordingViewModel.videoFileURL {

--- a/Lumbly/Sources/Features/Video/Playback/PlaybackViewModel.swift
+++ b/Lumbly/Sources/Features/Video/Playback/PlaybackViewModel.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 extension PlaybackView {
-    class PlaybackViewModel: ObservableObject {
-        @Published var recordingViewModel: RecordingView.RecordingViewModel
+    class ViewModel: ObservableObject {
+        @Published var recordingViewModel: RecordingView.ViewModel
         
-        init(recordingViewModel: RecordingView.RecordingViewModel) {
+        init(recordingViewModel: RecordingView.ViewModel) {
             self.recordingViewModel = recordingViewModel
         }
         

--- a/Lumbly/Sources/Features/Video/Recording/HostedRecordingViewController.swift
+++ b/Lumbly/Sources/Features/Video/Recording/HostedRecordingViewController.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import Combine
 
 struct HostedRecordingViewController: UIViewControllerRepresentable {
-    var viewModel: Binding<RecordingView.RecordingViewModel>
+    var viewModel: Binding<RecordingView.ViewModel>
     var viewControllerLink: RecordingViewControllerLink
     
     func makeUIViewController(context: Context) -> UIViewController {
@@ -26,7 +26,7 @@ struct HostedRecordingViewController: UIViewControllerRepresentable {
     
     class Coordinator: RecordingViewControllerDelegate {
         private var cancellable: AnyCancellable?
-        var viewModelBinding: Binding<RecordingView.RecordingViewModel>
+        var viewModelBinding: Binding<RecordingView.ViewModel>
         var viewController: RecordingViewControllerLinkable?
         
         var viewControllerLink: RecordingViewControllerLink? {
@@ -40,7 +40,7 @@ struct HostedRecordingViewController: UIViewControllerRepresentable {
             }
         }
         
-        init(viewModelBinding: Binding<RecordingView.RecordingViewModel>) {
+        init(viewModelBinding: Binding<RecordingView.ViewModel>) {
             self.viewModelBinding = viewModelBinding
         }
         

--- a/Lumbly/Sources/Features/Video/Recording/RecordingModals/RecordingInfoModal/RecordingInfoModalView.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingModals/RecordingInfoModal/RecordingInfoModalView.swift
@@ -20,7 +20,7 @@ struct RecordingInfoModalView<DestinationView: View>: View {
 
     @State var bodyTextSize: CGSize = .zero
 
-    @State var viewModel: RecordingInfoModalViewModel
+    @State var viewModel: ViewModel
     
     var body: some View {
         VStack(spacing: .nanoSpace) {

--- a/Lumbly/Sources/Features/Video/Recording/RecordingModals/RecordingInfoModal/RecordingInfoModalViewModel.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingModals/RecordingInfoModal/RecordingInfoModalViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension RecordingInfoModalView {
-    class RecordingInfoModalViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         var exerciseName: String
         var bodyText: String?
         var isTestRun: Bool

--- a/Lumbly/Sources/Features/Video/Recording/RecordingModals/RecordingOptionsModal/RecordingOptionsModalView.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingModals/RecordingOptionsModal/RecordingOptionsModalView.swift
@@ -15,7 +15,7 @@ struct RecordingOptionsModalView<OptionView: View>: View {
     
     private let constants = Constants()
     
-    var viewModel: RecordingOptionsModalViewModel
+    var viewModel: ViewModel
     
     var body: some View {
         VStack(spacing: .zero) {

--- a/Lumbly/Sources/Features/Video/Recording/RecordingModals/RecordingOptionsModal/RecordingOptionsModalViewModel.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingModals/RecordingOptionsModal/RecordingOptionsModalViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension RecordingOptionsModalView {
-    class RecordingOptionsModalViewModel {
+    class ViewModel {
         @Published var text: String
         @Published var showOptions: Bool
         @Published var leftOptionString: String?

--- a/Lumbly/Sources/Features/Video/Recording/RecordingView.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingView.swift
@@ -45,7 +45,7 @@ struct RecordingView: View {
     
     @State private var isRecording = false
     @State var shouldPresentPlayback = false
-    @State var viewModel: RecordingViewModel
+    @State var viewModel: ViewModel
     
     var body: some View {
         ZStack {

--- a/Lumbly/Sources/Features/Video/Recording/RecordingViewModel.swift
+++ b/Lumbly/Sources/Features/Video/Recording/RecordingViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension RecordingView {
-    class RecordingViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         @Published private(set) var isTestRun: Bool
         @Published private(set) var parentExerciseSet: String
         @Published private(set) var exerciseName: String

--- a/LumblyCore/Components/Gif/GifView.swift
+++ b/LumblyCore/Components/Gif/GifView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct GifView: View {
-    @StateObject var viewModel: GifViewModel
+    @StateObject var viewModel: ViewModel
     
     var body: some View {
         Group {

--- a/LumblyCore/Components/Gif/GifViewModel.swift
+++ b/LumblyCore/Components/Gif/GifViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension GifView {
-    class GifViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         enum LoadStatus {
             case success
             case failure

--- a/LumblyCore/Components/StyledTextField/StyledTextFieldView.swift
+++ b/LumblyCore/Components/StyledTextField/StyledTextFieldView.swift
@@ -13,7 +13,7 @@ struct StyledTextFieldView: View {
         return viewModel.title + suffix
     }
     
-    @StateObject var viewModel: StyledTextFieldViewModel
+    @StateObject var viewModel: ViewModel
     
     var body: some View {
         Group {

--- a/LumblyCore/Components/StyledTextField/StyledTextFieldViewModel.swift
+++ b/LumblyCore/Components/StyledTextField/StyledTextFieldViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension StyledTextFieldView {
-    class StyledTextFieldViewModel: ObservableObject {
+    class ViewModel: ObservableObject {
         @Binding var text: String
         
         private(set) var title: String


### PR DESCRIPTION
Shortened the name of each view model by removing the redundant prefix.

For example,
`ExerciseInstructionsView.ExerciseInstructionsViewModel`
becomes
`ExerciseInstructionsView.ViewModel`