### PR TITLE
Remove unnecessary parentheses after `.onAppear` calls

### DIFF
--- a/Lumbly/Sources/Features/Video/Playback/PlaybackView.swift
+++ b/Lumbly/Sources/Features/Video/Playback/PlaybackView.swift
@@ -40,7 +40,7 @@ struct PlaybackView: View {
         if let videoFileURL = viewModel.recordingViewModel.videoFileURL {
             VideoPlayer(player: player)
                 .ignoresSafeArea()
-                .onAppear() {
+                .onAppear {
                     AppDelegate.orientationLock = UIInterfaceOrientationMask.landscapeRight
                     
                     player = AVPlayer(url: videoFileURL)

--- a/LumblyCore/Components/Gif/GifView.swift
+++ b/LumblyCore/Components/Gif/GifView.swift
@@ -21,7 +21,7 @@ struct GifView: View {
                 ErrorLoadingContentView(errorText: L10n.ErrorLoadingContentView.contentError)
             }
         }
-        .onAppear() {
+        .onAppear {
             viewModel.fetchGifData()
         }
     }


### PR DESCRIPTION
Remove unnecessary parentheses after `.onAppear` calls in `PlaybackView` and `GifView`